### PR TITLE
style: improve settings page styling and mobile safari scrolling

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -34,7 +34,7 @@ function AppContent() {
   }, [currentPath]);
 
   return (
-    <div className="h-screen flex flex-col items-center bg-white-100 dark:bg-neutral-900 overflow-hidden">
+    <div className="h-dvh flex flex-col items-center bg-white-100 dark:bg-neutral-900 custom-scrollbar overflow-x-hidden overflow-y-auto">
       <Header />
       {page}
       <Footer />

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -29,7 +29,7 @@ const entries = [
 
 export function Footer() {
   return (
-    <footer className="w-full mt-auto border-t border-border bg-background/80 backdrop-blur-sm">
+    <footer className="w-full mt-auto border-t border-border bg-background/80 backdrop-blur-sm sticky bottom-0 z-10">
       <div className="max-w-7xl mx-auto px-4 py-6">
         <div className="flex justify-center items-center gap-1">
           {entries.map((entry, index) => (

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,7 +3,7 @@ import { ThemeToggle } from "./theme-toggle";
 
 export function Header() {
   return (
-    <div className="w-full flex justify-between items-center p-4">
+    <div className="w-full flex justify-between items-center p-4 sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
       <div className="flex gap-4">
         <Link to="/">Home</Link>
         <Link to="/settings">Settings</Link>

--- a/src/components/layout/page.tsx
+++ b/src/components/layout/page.tsx
@@ -1,8 +1,6 @@
 export function Page({ children, centered = false }: { children: React.ReactNode; centered?: boolean }) {
   return (
-    <div
-      className={`flex-1 flex flex-col items-center max-w-2xl w-full px-4 overflow-hidden ${centered ? "justify-center" : ""}`}
-    >
+    <div className={`flex-1 flex flex-col items-center max-w-2xl w-full px-4 ${centered ? "justify-center" : ""}`}>
       {children}
     </div>
   );

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -8,23 +8,21 @@ import { Card } from "@/components/ui/card";
 export function SettingsPage() {
   return (
     <Page>
-      <h1 className="text-6xl md:text-7xl font-light mb-16 text-gray-800 dark:text-gray-100 select-none tracking-wide flex-shrink-0">
+      <h1 className="text-6xl md:text-7xl font-light mb-16 mt-8 text-gray-800 dark:text-gray-100 select-none tracking-wide flex-shrink-0">
         Gulgle Settings
       </h1>
 
       <div className="flex-1 w-full relative">
-        <div className="absolute inset-0 overflow-y-auto custom-scrollbar">
-          <div className="space-y-8 max-w-4xl mx-auto pr-6">
-            <DefaultBangSelection />
-            <Card className="p-6">
-              <div>
-                <h3 className="text-lg font-semibold">Custom Bangs</h3>
-              </div>
-              <CustomBangsList />
-              <AddBangForm />
-            </Card>
-            <ImportExportSettings />
-          </div>
+        <div className="space-y-8 max-w-4xl mx-auto mb-6">
+          <DefaultBangSelection />
+          <Card className="p-6">
+            <div>
+              <h3 className="text-lg font-semibold">Custom Bangs</h3>
+            </div>
+            <CustomBangsList />
+            <AddBangForm />
+          </Card>
+          <ImportExportSettings />
         </div>
       </div>
     </Page>


### PR DESCRIPTION
- fix double scroll on safari on iOS
- change page layout and make top and bottom bars `position: sticky` to improve scrolling physics on safari
- add background color and blur to top-bar


before:

https://github.com/user-attachments/assets/b38c3d7c-9cca-4416-b99a-baf7fc0956a8

after:

https://github.com/user-attachments/assets/db6f4b60-daaf-4881-8943-30f60f5b73cd

